### PR TITLE
😬 revert pinning changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-utils"
-version = "0.6.0"
+version = "0.5.0"
 dependencies = [
  "lazy_static",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Fastly"]
 edition = "2018"
 name = "prometheus-utils"
-version = "0.6.0"
+version = "0.5.0"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "Utilities built on top of the prometheus crate"
 


### PR DESCRIPTION
This reverts the changes in c27dd7d and 3a1fd36. Unfortunately, #3 was
founded on some slight misunderstandings of `Pin` semantics — namely,
that our underlying future _will_ be pinned when an instrumented future
is itself pinned.

`pin_project` will generate code that prevents UB, and when an
instrumented future is `.await`ed, the executor will pin it for us.
Because pinning is structural for the inner future `F`, it too will be
pinned and our poll calls will function properly.

If the caller aims to poll the instrumented future directly, then the
responsibility to pin it (_either to the heap via `Box::pin`, or to the stack
via macros like `tokio::pin!` or `pin_utils::pin_mut!`_) is no different than
any other `Future`.

Apologies for the false alarms, but I am happy to know that this is (and
was) functioning like it should. :adhesive_bandage: 