### PR TITLE
🍱 address `dyn_drop` lint

### DIFF
--- a/src/instrumented_future.rs
+++ b/src/instrumented_future.rs
@@ -1,3 +1,11 @@
+//! Utilities for instrumenting asynchronous code.
+//
+//  `dyn_drop` is explicitly allowed in this module. As this lint indicates, `Drop` bounds are not
+//  a proper heuristic for checking that a type can be trivially dropped. In our case, an
+//  instrumented future is responsible for dealing with resource guards whose primary functionality
+//  /is/ their drop implementations.
+#![allow(dyn_drop)]
+
 use super::{GuardedGauge, IntCounterWithLabels, Labels};
 use pin_project::pin_project;
 use prometheus::core::{Atomic, GenericCounter};


### PR DESCRIPTION
 ### 🎨 background

this lint warns about our `Drop` bounds:
- https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#dyn-drop
- https://github.com/rust-lang/rust/pull/86848

quoth the lint:

> A trait object bound of the form dyn Drop is most likely misleading
> and not what the programmer intended.
>
> Drop bounds do not actually indicate whether a type can be trivially
> dropped or not, because a composite type containing Drop types does
> not necessarily implement Drop itself. Naïvely, one might be tempted
> to write a deferred drop system, to pull cleaning up memory out of a
> latency-sensitive code path, using dyn Drop trait objects. However,
> this breaks down e.g. when T is String, which does not implement Drop,
> but should probably be accepted.

 ### ➕ changes

there are two ways to solve this problem: (1) allow `dyn_drop`, or (2)
remove `Drop` bounds from our API's. it's worth noting that the latter
would be a breaking change.

so, `dyn_drop` is explicitly allowed in the `instrumented_future`
module. As this lint indicates, `Drop` bounds are not a proper heuristic
for checking that a type can be trivially dropped. In our case, an
instrumented future is responsible for dealing with resource guards
whose primary functionality /is/ their drop implementations.

i don't believe that `InstrumentedFuture`, or its API surface, aims to
be generic across all droppable types `T`. the lint in question, and
conversation surrounding it, provides `String` as an example of a
droppable type that is not `Drop` itself. putting such a value into the
instrumented future wouldn't have any useful effect.

all of this machinery hinges on `Drop`, so my vote is to keep that
explicit in the trait bounds, and consider this an exception to this
lint.