### PR TITLE
reduce stack space; fix dyn_drop lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Fastly"]
 edition = "2018"
 name = "prometheus-utils"
-version = "0.5.1"
+version = "0.6.0"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "Utilities built on top of the prometheus crate"
 repository = "https://github.com/fastly/prometheus-utils"

--- a/src/instrumented_future.rs
+++ b/src/instrumented_future.rs
@@ -1,7 +1,7 @@
 use super::{GuardedGauge, IntCounterWithLabels, Labels};
 use pin_project::pin_project;
 use prometheus::core::{Atomic, GenericCounter};
-use std::{future, ops::Deref, pin::Pin, task, any::Any};
+use std::{any::Any, future, ops::Deref, pin::Pin, task};
 
 /// An instrumented [`Future`][std-future].
 ///

--- a/src/instrumented_future.rs
+++ b/src/instrumented_future.rs
@@ -1,7 +1,7 @@
 use super::{GuardedGauge, IntCounterWithLabels, Labels};
 use pin_project::pin_project;
 use prometheus::core::{Atomic, GenericCounter};
-use std::{future, ops::Deref, pin::Pin, task};
+use std::{future, ops::Deref, pin::Pin, task, any::Any};
 
 /// An instrumented [`Future`][std-future].
 ///
@@ -56,7 +56,7 @@ pub struct InstrumentedFuture<F: future::Future> {
     ///
     /// In practice, this holds a list of Prometheus counters or gauges to increment when the inner
     /// `Future` starts, returning a list of guards to decrement once the inner `Future` completes.
-    pre_polls: Vec<Box<dyn FnOnce() -> Option<Box<dyn Drop + Send>> + Send>>,
+    pre_polls: Vec<Box<dyn FnOnce() -> Option<Box<dyn Any + Send>> + Send>>,
     /// RAII guards that will be dropped once the future has resolved.
     ///
     /// In practice, this is used to hold values like [`IntGaugeGuard`][int-guard] and
@@ -68,7 +68,8 @@ pub struct InstrumentedFuture<F: future::Future> {
     /// [float-guard]: type.GaugeGuard.html
     /// [int-guard]: type.IntGaugeGuard.html
     /// [inc-until]: struct.InstrumentedFuture.html#method.increment_until_resolved
-    resource_guards: Vec<Box<dyn Drop + Send>>,
+    #[allow(dyn_drop)]
+    resource_guards: Vec<Box<dyn Any + Send>>,
 }
 
 /// Convert a [`Future`][future::Future] into an instrumented future.
@@ -129,7 +130,7 @@ impl<F: future::Future> InstrumentedFuture<F> {
     ///         .await;
     /// }
     /// ```
-    pub fn with_guard<GuardFn: FnOnce() -> Option<Box<dyn Drop + Send>> + Send + 'static>(
+    pub fn with_guard<GuardFn: FnOnce() -> Option<Box<dyn Any + Send>> + Send + 'static>(
         mut self,
         guard_fn: GuardFn,
     ) -> Self {

--- a/src/percentile.rs
+++ b/src/percentile.rs
@@ -70,7 +70,7 @@ const WINDOW_SIZE: usize = 4096;
 struct ObservationSet<T: Ord + Zero + Copy> {
     idx: usize,
     wraps: usize,
-    data: [T; WINDOW_SIZE],
+    data: Box<[T]>,
 }
 
 impl<T: Ord + Zero + Copy> ObservationSet<T> {
@@ -78,7 +78,8 @@ impl<T: Ord + Zero + Copy> ObservationSet<T> {
         Self {
             idx: 0,
             wraps: 0,
-            data: [T::zero(); WINDOW_SIZE],
+            // Construct in a manner that doesnt use stack space - Box::new([0; WINDOW_SIZE]) would
+            data: vec![T::zero(); WINDOW_SIZE].into_boxed_slice(),
         }
     }
 


### PR DESCRIPTION
Box the `ObservationSet::data` field so that it can be constructed without using stack space, by using `vec![0; LEN].into_boxed_slice()`.

On InstrumentedFuture, use dyn Any instead of dyn Drop. This preserves the desired semantics, which is to store an owned object whose Drop will run later, without running afoul the new dyn_drop lint.
 
Bump package version to 0.6.0.