### PR TITLE
✨ labels: introduce a labeled histogram

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,9 @@ pub use guards::{
     GuardedGauge, IntGaugeGuard,
 };
 pub use instrumented_future::{InstrumentedFuture, IntoInstrumentedFuture};
-pub use labels::{IntCounterWithLabels, IntGaugeWithLabels, LabelValues, Labels};
+pub use labels::{
+    HistogramWithLabels, IntCounterWithLabels, IntGaugeWithLabels, LabelValues, Labels,
+};
 pub use percentile::{Observations, Sample, TimingBucket, Windowing};
 
 #[allow(missing_docs)]


### PR DESCRIPTION
this introduces a labeled version of `prometheus::Histogram`, much like
the existing `IntGaugeWithLabels` or `IntCounterWithLabels` provide
labeled equivalents to `prometheus::IntGauge` and
`prometheus::IntCounter`, respectively.

this is implemented using a `prometheus::HistogramVec`, and includes the
same interfaces that `prometheus::Histogram` presents, with label
parameters added.